### PR TITLE
Raissa - sincronia

### DIFF
--- a/docs/sincronia.md
+++ b/docs/sincronia.md
@@ -9,3 +9,11 @@ Tente sempre deixar as legendas disponíveis na tela por um tempo suficiente par
 ## Velocidade de Leitura
 
 A velocidade de leitura de cada legenda não deve exceder o limite de 21 caracteres por segundo. O editor de legendas do Amara marcará com um pequeno ponto de exclamação vermelho (`!`) para facilitar a identificação de qualquer legenda com velocidade de leitura acima desse limite. Por isso, antes de concluir qualquer tarefa, verifique se há algum trecho que precise de ajuste na velocidade leitura.
+
+Para saber mais como sincronizar as legendas:
+
+https://www.youtube.com/watch?v=yvNQoD32Qqo&list=PLuvL0OYxuPwxQbdq4W7TCQ7TBnW39cDRC&index=5
+
+https://www.youtube.com/watch?v=QVz0XyEAbHU&list=PLuvL0OYxuPwxQbdq4W7TCQ7TBnW39cDRC&index=8
+
+


### PR DESCRIPTION
1. Sobre esta parte: "e evita o efeito de transição em que a legenda parece piscar", parece que houve uma orientação do Krystian, pelo menos para as TED talks, de que sejam mantidos esses espaços, com essas piscadelas ou gaps. 

http://translations.ted.org/wiki/Template:GoodSubtitles


"Note on gaps between subtitles

"In many transcripts, you will see regular tiny gaps between subtitles. If possible, please do not edit these gaps in your translation, as they are used for technical reasons: they prevent two consecutive subtitles from overlapping in some players, and they help the user's brain to register the change of subtitle."

2. Estou sugerindo colocarmos aqui links para os vídeos "OTP Learning Series 05: Subtitle length and reading speed" e "OTP Learning Series 08: How to tackle reading-speed issues". Eles são muito úteis para o tópico da "Sincronia".