### PR TITLE
Termos estrangeiros - Raissa

### DIFF
--- a/docs/termos_estrangeiros.md
+++ b/docs/termos_estrangeiros.md
@@ -4,7 +4,7 @@ Ao traduzir uma palestra, pode-se deparar com:
 
 - Espécie
 
-- Eventos Históricos
+- Eventos históricos
 
 - Filme
 
@@ -46,19 +46,19 @@ Exemplos:
 
 ## Estrangeirismos
 
-Caso encontre estrangeirismos durante a tradução, verifique se existe termo equivalente na língua portuguesa. Sempre que existir, opte por usá-lo. Esta verificação pode ser feita consultando-se o Vocabulário Ortográfico da Língua Portuguesa (VOLP), da Academia Brasileira de Letras, [nesse link](http://www.academia.org.br/abl/cgi/cgilua.exe/sys/start.htm?sid=23). Exemplos:
+Caso encontre estrangeirismos durante a tradução, verifique se existe termo equivalente no português brasileiro. Sempre que existir, opte por usá-lo. Esta verificação pode ser feita consultando-se o Vocabulário Ortográfico da Língua Portuguesa (VOLP), da Academia Brasileira de Letras, [nesse link](http://www.academia.org.br/abl/cgi/cgilua.exe/sys/start.htm?sid=23). Exemplos:
 
-- Cartum (em vez de “cartoon”)
+- cartum (em vez de “cartoon”)
 
 - drinque (em vez de “drink”)
 
-- escâner (em vez de “scanner”)
+- escâner ou escaneador (em vez de “scanner”)
 
 - leiaute (em vez de “layout”)
 
-Caso não exista equivalente na língua portuguesa, não sendo possível traduzir de outra forma o trecho em que a palavra se encontra, repita a palavra estrangeira entre aspas na tradução, exceto os estrangeirismos listados no [Manual de Comunicação da Secom](http://www12.senado.gov.br/manualdecomunicacao/redacao-e-estilo/estilo/estrangeirismos-grafados-sem-italico), que não são grafados entre aspas. Exemplos:
+Caso não exista equivalente na língua portuguesa, não sendo possível traduzir de outra forma o trecho em que a palavra se encontra, repita a palavra estrangeira entre aspas na primeira vez em que ela for mencionada na tradução, exceto os estrangeirismos listados no [Manual de Comunicação da Secom](http://www12.senado.gov.br/manualdecomunicacao/redacao-e-estilo/estilo/estrangeirismos-grafados-sem-italico), que são grafados sem aspas. Exemplos:
 
-> "Eles o consideram um “geek”."
+> "Eles o consideram um 'geek'."
 
 > "O leiaute dos andares do edifício foi reformulado."
 


### PR DESCRIPTION
1. No exemplo do "geek", temos uma boa oportunidade para exemplificar a questão das aspas simples e das aspas duplas, além da questão do estrangeirismo. Daí a sugestão de alteração acima.
2. Será que é o caso de se utilizar entre aspas a tradução de siglas? Fiquei pensando, por exemplo, na sigla ONU (UN em inglês). Acho que não é necessário usar entre aspas. Talvez eu não esteja me lembrando de exemplos em que isso seria necessário. Também não consegui achar um exemplo com personalidades. Acho que isso acontece mais com apelidos como: "o rei do futebol", etc.