### PR TITLE
Update tedx.md

### DIFF
--- a/docs/tedx.md
+++ b/docs/tedx.md
@@ -4,7 +4,7 @@
 
 ## Formato do Título e da Descrição de Palestras TEDx
 
-Cada palestra TEDx normalmente vem com um título e uma descrição, os quais são adicionados pelo organizador do evento, e são importadas do YouTube para o Amara. Nem sempre, porém, o título vem no formato-padrão. Normalmente isso é verificado e adequado quando é feita a transcrição da palestra (idioma original). Caso você esteja realizando uma tarefa de transcrição em PT-BR e não haja título na palestra, procure você mesmo dar um título à palestra ou contactar o organizador ou o palestrante, pedindo que sugiram um nome para a palestra.
+Cada palestra TEDx normalmente vem com um título e uma descrição, os quais são adicionados pelo organizador do evento, e são importadas do YouTube para o Amara. Nem sempre, porém, o título vem no formato padrão. Normalmente isso é verificado e adequado quando é feita a transcrição da palestra (idioma original). Caso você esteja realizando uma tarefa de transcrição em PT-BR e não haja título na palestra, procure você mesmo dar um título a ela ou contactar o organizador ou o palestrante, pedindo que sugiram um nome para a palestra.
 
 ### Título
 Ao transcrever palestras TEDx em Pt-Br ou ao traduzi-las para Pt-Br, siga o seguinte formato de título:
@@ -23,16 +23,18 @@ Use letra maiúscula apenas na primeira palavra do título, em nomes próprios e
 
 > “A história da eletricidade | Palestrante Fictício | TEDxQualquer” em vez de “A História Da Eletricidade ...”
 
-
-
-
 ### Descrição
-A descrição das palestras TEDx deve ser um breve resumo da palestra. Caso haja links para outros sites, exclua-os (exceto se forem da organização do palestrante, se esta for objeto da palestra). Se a descrição contiver a biografia do palestrante, você pode mantê-la, **mas exclua o texto que fala sobre o que é o programa TEDx** (“In the spirit of ideas worth spreading, TEDx is a program of local, self-organized events…”).
+A descrição das palestras TEDx deve ser um breve resumo destas. Caso haja links para outros sites, exclua-os (exceto se forem da organização do palestrante, se esta for objeto da palestra). Se a descrição contiver a biografia do palestrante, você pode mantê-la, **mas exclua o texto que fala sobre o que é o programa TEDx** (“In the spirit of ideas worth spreading, TEDx is a program of local, self-organized events…”).
+
+Disclaimer das palestras TEDX:
+Na descrição das palestras TEDx é preciso traduzir (ou incluir) o "disclaimer", usando a tradução oficial:
+"Esta palestra foi dada em um evento TEDx, que usa o formato de conferência TED, mas é organizado de forma independente por uma comunidade local. Para saber mais, visite http://ted.com/tedx"
 
 **Nas lições TED-Ed, o link para a lição completa deve permanecer, assim como os créditos no fim da descrição (“Lesson by... Animation by...).**
+No entanto, não é preciso traduzir os créditos que às vezes são mostrados na tela do final de algumas lições TED-Ed.
 
 As palestras TEDx também poderão conter a seguinte frase-padrão: “This talk was given at a TEDx event using the TED conference format but independently organized by a local community. Learn more at http://ted.com/tedx”. A tradução padronizada desta frase encontra-se em [Glossário](glossario.md).
 
-## Palestras TED e TEDx semelhantes
+## Versões TED e TEDx de uma mesma palestra
 
 Pode-se deparar com tarefas de tradução de palestras TED e TEDx aparentemente iguais, com mesmos título e palestrante. Isso acontece quando essas são escolhidas pela equipe do TED para figurarem no [site](www.ted.com), por isso são reeditadas e ficam ligeiramente diferentes. As tarefas coexistem e são independentes, não há abandono de uma delas quando a outra é finalizada.


### PR DESCRIPTION
1. No "Formato do Título"... substituí "à palestra" por "a ela", para evitar repetir demais a palavra "palestra".
2. Imagino que o disclaimer esteja em outro lugar, mas acho que vale a pena deixar aqui, uma vez que ele se encontra dentro da descrição da palestra. 
3. Inseri a frase "No entanto, não é preciso traduzir os créditos que às vezes são mostrados na tela do final de algumas lições TED-Ed", pois tenho notado que algumas lições TED-Ed estão vindo com esses créditos, e às vezes o tradutor resolve traduzi-los, mesmo eles não estando transcritos no original em inglês.