### PR TITLE
Aprimorar exemplos do item "Termos Estrangeiros"

### DIFF
--- a/docs/termos_estrangeiros.md
+++ b/docs/termos_estrangeiros.md
@@ -28,11 +28,11 @@ No campo de descrição da palestra, é possível usar a tradução, entre parê
 
 Exemplos:
 
-> "O Cerrado, o segundo maior bioma da América do Sul, protege 5% de todas as espécies do planeta e três em cada dez espécies brasileiras, entre elas, plantas como o pequi, “Caryocar brasiliense”, e animais como o lobo-guará, “Chrysocyon brachyurus”."
+> O Cerrado, o segundo maior bioma da América do Sul, protege plantas como o pequi, “Caryocar brasiliense”, e animais como o lobo-guará, “Chrysocyon brachyurus”.
 
-> "O filme “Spotlight: segredos revelados” ganhou o Oscar de melhor filme em 2016."
+> “Spotlight: segredos revelados” ganhou o Oscar de melhor filme em 2016.
 
-> "O livro “Memórias póstumas de Brás Cubas” foi escrito por Machado de Assis."
+> O livro “Memórias póstumas de Brás Cubas” foi escrito por Machado de Assis.
 
 > Tiananmen Square -> Praça da Paz Celestial
 


### PR DESCRIPTION
Olá,Túlio,

Estou propondo essas alterações, retirando algumas aspas desses exemplos, para evitar usar aspas simples dentro das aspas duplas.
Uma outra solução seria manter os exemplos como estavam e colocar aspas simples nos títulos usados. 
O objetivo aqui é mostrar o uso das aspas em obras literárias, filmes, etc.
Assim, retirei as aspas que iniciam os exemplos e deixei somente nos títulos do filme, do livro e no nome da planta e do animal, para chamar a atenção para isso.
Um abraço,
Raissa