### PR TITLE
Uso das aspas discurso direto

### DIFF
--- a/docs/aspas_direto.md
+++ b/docs/aspas_direto.md
@@ -2,6 +2,6 @@
 
 Além de usar as aspas para destacar palavras estrangeiras sem tradução em português e não listadas entre as palavras estrangeiras que não devem ser grafadas com aspas, no Manual de Comunicação da Secom, use-as também para destacar o discurso direto na tradução. Em textos literários em língua portuguesa, o discurso direto é normalmente destacado com um travessão   (–) no início do discurso. Porém, o travessão pode não aparecer de forma correta na tela, dependendo do player de vídeo em que se assiste à palestra. Assim, sempre que houver discurso direto, empregue os dois pontos, seguidos pelo discurso entre aspas, começando a frase com letra maiúscula, caso seja uma citação. Exemplos:
 
-> "Então, eu perguntei: “Por que você não vai à festa?”. Ela respondeu: “Porque tenho trabalho da faculdade para terminar”.
+> Então, eu perguntei: “Por que você não vai à festa?”. Ela respondeu: “Porque tenho trabalho da faculdade para terminar”.
 
-> 'Depois de ouvir o que diziam, pensei: “Mas o que será que aconteceu?”'
+> Depois de ouvir o que diziam, pensei: “Mas o que será que aconteceu?”


### PR DESCRIPTION
Olá, Túlio!
Tudo bem?
Acho que não consegui fazer as alterações que queria no meu pull request anterior.
O objetivo foi tirar as aspas do início dos exemplos, para deixar bem claro, nas legendas, como se usam as aspas com o discurso direto.
Acho que agora consegui fazer. Vamos ver.
Um abraço!